### PR TITLE
Ansible lint

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # handlers file for host-docker
-- name: restart docker
+- name: Restart docker
   ansible.builtin.service:
     name: docker
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 ---
 # handlers file for host-docker
 - name: restart docker
-  service:
+  ansible.builtin.service:
     name: docker
     state: restarted
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     mode: '0644'
   register: apt_repo
 
-- name: Update package cache  # noqa 503
+- name: Update package cache  # noqa: no-handler
   ansible.builtin.apt:
     update_cache: true
   when: apt_repo.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,9 @@
   ansible.builtin.template:
     src: templates/docker.list.j2
     dest: /etc/apt/sources.list.d/docker.list
+    owner: root
+    group: root
+    mode: '0644'
   register: apt_repo
 
 - name: Update package cache  # noqa 503

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,12 +27,12 @@
       - gnupg2
       - software-properties-common
 
-- name: add Docker apt-key
+- name: Add Docker apt-key
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/debian/gpg
     state: present
 
-- name: add Docker's APT repository
+- name: Add Docker's APT repository
   ansible.builtin.template:
     src: templates/docker.list.j2
     dest: /etc/apt/sources.list.d/docker.list
@@ -43,7 +43,7 @@
     update_cache: true
   when: apt_repo.changed
 
-- name: install Docker
+- name: Install Docker
   ansible.builtin.package:
     name: "{{ packages }}"
     state: present
@@ -57,7 +57,7 @@
     src: templates/daemon.json.j2
     dest: /etc/docker/daemon.json
     mode: "0644"
-  notify: restart docker
+  notify: Restart docker
 
 - name: Check current docker-compose version.
   ansible.builtin.command: docker-compose --version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,16 +8,16 @@
 ---
 # tasks file for host-docker
 - name: Gather package facts
-  package_facts:
+  ansible.builtin.package_facts:
     manager: "auto"
 
 - name: Exit if docker.io is installed
-  fail:
+  ansible.builtin.fail:
     msg: "Please remove docker.io (Debian vanilla docker package) first!"
   when: "'docker.io' in ansible_facts.packages"
 
 - name: Install Docker APT deps
-  package:
+  ansible.builtin.package:
     name: "{{ packages }}"
     state: present
   vars:
@@ -28,7 +28,7 @@
       - software-properties-common
 
 - name: add Docker apt-key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://download.docker.com/linux/debian/gpg
     state: present
 
@@ -44,7 +44,7 @@
   when: apt_repo.changed
 
 - name: install Docker
-  package:
+  ansible.builtin.package:
     name: "{{ packages }}"
     state: present
   vars:
@@ -53,20 +53,20 @@
       - python3-docker
 
 - name: Set docker configuration
-  template:
+  ansible.builtin.template:
     src: templates/daemon.json.j2
     dest: /etc/docker/daemon.json
     mode: "0644"
   notify: restart docker
 
 - name: Check current docker-compose version.
-  command: docker-compose --version
+  ansible.builtin.command: docker-compose --version
   register: docker_compose_current_version
   changed_when: false
   failed_when: false
 
 - name: Delete existing docker-compose version if it's different.
-  file:
+  ansible.builtin.file:
     path: "{{ docker_compose_path }}"
     state: absent
   when: >
@@ -74,13 +74,13 @@
     and docker_compose_version not in docker_compose_current_version.stdout
 
 - name: Install Docker Compose (if configured).
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
     dest: "{{ docker_compose_path }}"
     mode: "0755"
 
 - name: Place admin users in docker group
-  user:
+  ansible.builtin.user:
     name: "{{ item.logname }}"
     groups: [docker]
     append: yes


### PR DESCRIPTION
All green now:

```
adahl@ada-pc ..ata/adahl/src/ansible-role-host-docker (git)-[ansible-lint] % ansible-lint 

Passed with production profile: 0 failure(s), 0 warning(s) on 12 files.
```
