### PR TITLE
Simplify Docker Compose Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Ansible Role for installing the Docker runtime environment on your (Debian) host
 This role can be installed through your *requirements.yml*, either from
 [Ansible Galaxy](https://galaxy.ansible.com/) or through the Git repo.
 
+Please note that `docker-compose` is now a part of the Docker client and
+available through the `docker compose` command.
+
 ## Role Variables
 
 *A description of the settable variables for this role should go here,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 # defaults file for host-docker
-docker_compose_version: "1.27.4"
-docker_compose_path: /usr/local/bin/docker-compose
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
   vars:
     packages:
       - docker-ce
+      - docker-compose-plugin
       - python3-docker
 
 - name: Set docker configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,26 +62,6 @@
     mode: "0644"
   notify: Restart docker
 
-- name: Check current docker-compose version.
-  ansible.builtin.command: docker-compose --version
-  register: docker_compose_current_version
-  changed_when: false
-  failed_when: false
-
-- name: Delete existing docker-compose version if it's different.
-  ansible.builtin.file:
-    path: "{{ docker_compose_path }}"
-    state: absent
-  when: >
-    docker_compose_current_version.stdout is defined
-    and docker_compose_version not in docker_compose_current_version.stdout
-
-- name: Install Docker Compose (if configured).
-  ansible.builtin.get_url:
-    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
-    dest: "{{ docker_compose_path }}"
-    mode: "0755"
-
 - name: Place admin users in docker group
   ansible.builtin.user:
     name: "{{ item.logname }}"


### PR DESCRIPTION
This PR simplifies our Docker Compose setup by eliminating the need for an external docker-compose script. The changes are in line with the latest Docker practices, which have [integrated docker-compose features directly into Docker](https://docs.docker.com/compose/migrate/).

This also fixes #4 .