### PR TITLE
:alien: Modernize apt key handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 ---
 # defaults file for host-docker
 docker_apt_key_url: "https://download.docker.com/linux/debian/gpg"
+docker_apt_keyrings_dir: "/etc/apt/keyrings"
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # defaults file for host-docker
+
+# docker_apt_key_fpr: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"  # optional variable, only considered if set by user
 docker_apt_key_url: "https://download.docker.com/linux/debian/gpg"
 docker_apt_keyrings_dir: "/etc/apt/keyrings"
 docker_data_root: "/var/lib/docker"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # defaults file for host-docker
+docker_apt_key_url: "https://download.docker.com/linux/debian/gpg"
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,24 @@
         mode: '0644'
       register: apt_repo
 
+- name: Optionally get and check GPG fingerprint of apt key file
+  when: docker_apt_key_fpr is defined   # no need to get the fpr if user does not want to check it anyways
+  block:
+    - name: Get GPG fingerprint of downloaded key file
+      ansible.builtin.shell:
+        cmd: "gpg --with-colons --show-keys '{{ docker_apt_keyrings_dir }}/docker.asc' | grep -A1 '^pub:' | grep '^fpr:' | cut -d: -f10"
+      changed_when: false
+      register: gpg_fpr
+
+    - name: Assert GPG fingerprint of apt key file is the one provided by the user
+      ansible.builtin.assert:
+        that:
+          - not gpg_fpr.failed
+          - gpg_fpr.rc == 0
+          - gpg_fpr.stdout == docker_apt_key_fpr
+        fail_msg: "Docker APT key fingerprint does not match!"
+      when: (gpg_fpr.skipped is not defined) or not gpg_fpr.skipped
+
 - name: Update package cache  # noqa: no-handler
   ansible.builtin.apt:
     update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,13 @@
         mode: '0644'
       register: apt_repo
 
+    # that key was created in 2017 and was still in use in 2024,
+    # we most probably need to remove this one key only
+    - name: Remove key from deprecated apt-key storage
+      ansible.builtin.apt_key:
+        id: 0x9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+        state: absent
+
 - name: Optionally get and check GPG fingerprint of apt key file
   when: docker_apt_key_fpr is defined   # no need to get the fpr if user does not want to check it anyways
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,19 +27,34 @@
       - gnupg2
       - software-properties-common
 
-- name: Add Docker apt-key
-  ansible.builtin.apt_key:
-    url: "{{ docker_apt_key_url }}"
-    state: present
+# Link: https://docs.docker.com/engine/install/debian/#install-using-the-repository
+- name: Prepare apt with key and sources entry
+  block:
+    - name: Ensure apt keyrings dir is present
+      ansible.builtin.file:
+        path: "{{ docker_apt_keyrings_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
 
-- name: Add Docker's APT repository
-  ansible.builtin.template:
-    src: templates/docker.list.j2
-    dest: /etc/apt/sources.list.d/docker.list
-    owner: root
-    group: root
-    mode: '0644'
-  register: apt_repo
+    - name: Put docker apt release key in place
+      ansible.builtin.get_url:
+        url: "{{ docker_apt_key_url }}"
+        dest: "{{ docker_apt_keyrings_dir }}/docker.asc"
+        mode: '0644'
+        backup: true
+        force: true
+      register: apt_repo
+
+    - name: Add Docker's APT repository
+      ansible.builtin.template:
+        src: templates/docker.list.j2
+        dest: /etc/apt/sources.list.d/docker.list
+        owner: root
+        group: root
+        mode: '0644'
+      register: apt_repo
 
 - name: Update package cache  # noqa: no-handler
   ansible.builtin.apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Add Docker apt-key
   ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/debian/gpg
+    url: "{{ docker_apt_key_url }}"
     state: present
 
 - name: Add Docker's APT repository

--- a/templates/docker.list.j2
+++ b/templates/docker.list.j2
@@ -1,3 +1,3 @@
 {# SPDX-FileCopyrightText: 2022 Stefan Haun <tux@netz39.de> #}
 {# SPDX-License-Identifier: CC0-1.0 #}
-deb https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
+deb [arch={{ ansible_local['deb']['arch'] }} signed-by={{ docker_apt_keyrings_dir }}/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable


### PR DESCRIPTION
apt-key is deprecated.  Nowadays you put the GPG key of third party apt repo in a local file and reference that with "signed-by" from your sources.list snippet.  For not blindly trusting a key downloaded from some arbitrary URL, the current one is put to this repo now, it is this one:

    pub   rsa4096 2017-02-22 [SCEA]
          9DC858229FC7DD38854AE2D88D81803C0EBFCD88
    uid           Docker Release (CE deb) <docker@docker.com>
    sub   rsa4096 2017-02-22 [S]

This fixes at least the following warning I get by mail from one of the hosts I'm using this role on:

    W: https://download.docker.com/linux/debian/dists/bookworm/InRelease: Schlüssel ist im veralteten
    Schlüsselbund trusted.gpg gespeichert (/etc/apt/trusted.gpg), siehe den Abschnitt MISSBILLIGUNG in
    apt-key(8) für Details.

Link: https://manpages.debian.org/bookworm/apt/apt-key.8.en.html#DEPRECATION
Link: https://michael-prokop.at/blog/2021/02/16/how-to-properly-use-3rd-party-debian-repository-signing-keys-with-apt/
Link: https://wiki.debian.org/DebianRepository/UseThirdParty
Link: https://docs.docker.com/engine/install/debian/#install-using-the-repository