### PR TITLE
:bug: Allow missing attribute 'docker' in user dict

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,5 +68,5 @@
     name: "{{ item.logname }}"
     groups: [docker]
     append: yes
-  when: item.docker
+  when: (item.docker is defined) and item.docker
   with_items: "{{ users }}"


### PR DESCRIPTION
Previously if the (boolean) 'docker' member of a user definition was missing, the following error occured:

    TASK [host_docker : Place admin users in docker group] **************************************************************************************************************************************************
    fatal: [ada-pc]: FAILED! => {"msg": "The conditional check 'item.docker' failed. The error was: error while evaluating conditional (item.docker): 'dict object' has no attribute 'docker'. 'dict object' has no attribute 'docker'\n\nThe error appears to be in '/home/adahl/Work/admin/ansible/role-host-docker/tasks/main.yml': line 79, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Place admin users in docker group\n  ^ here\n"}

Allow the member to be missing and treat it the same as 'false'. In other words: to put a user in the docker group the attribute must exist _and_ set to *true* now.  Should not affect existing configurations with the attribute present.