### PR TITLE
:bug: Remove arch from sources.list line

### DIFF
--- a/templates/docker.list.j2
+++ b/templates/docker.list.j2
@@ -1,3 +1,3 @@
 {# SPDX-FileCopyrightText: 2022 Stefan Haun <tux@netz39.de> #}
 {# SPDX-License-Identifier: CC0-1.0 #}
-deb [arch={{ ansible_local['deb']['arch'] }} signed-by={{ docker_apt_keyrings_dir }}/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
+deb [signed-by={{ docker_apt_keyrings_dir }}/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable


### PR DESCRIPTION
The custom fact causes problems if not set:

     _________________________________________________________
    < TASK [netz39.host_docker : Add Docker's APT repository] >
     ---------------------------------------------------------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||

    task path: /home/alex/.ansible/roles/netz39.host_docker/tasks/main.yml:50
    redirecting (type: lookup) ansible.builtin.passwordstore to community.general.passwordstore
    redirecting (type: lookup) ansible.builtin.passwordstore to community.general.passwordstore
    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'deb'. 'dict object' has no attribute 'deb'
    fatal: [miraculix]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'deb'. 'dict object' has no attribute 'deb'"}

Probably slipped in from a playbook which put the deb arch to local facts.  We did not have arch before, and it does work without.  No clue why Docker has this in its documentation, it should only be necessary for special use cases anyway.

Fixes: #8
Fixes: b0e550fb736a (":alien: Modernize apt key handling")