### PR TITLE
:wrench: Make apt uri configurable through default variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@
 # docker_apt_key_fpr: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"  # optional variable, only considered if set by user
 docker_apt_key_url: "https://download.docker.com/linux/debian/gpg"
 docker_apt_keyrings_dir: "/etc/apt/keyrings"
+docker_apt_uri: "https://download.docker.com/linux/debian"
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""

--- a/templates/docker.list.j2
+++ b/templates/docker.list.j2
@@ -1,3 +1,3 @@
 {# SPDX-FileCopyrightText: 2022 Stefan Haun <tux@netz39.de> #}
 {# SPDX-License-Identifier: CC0-1.0 #}
-deb [signed-by={{ docker_apt_keyrings_dir }}/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
+deb [signed-by={{ docker_apt_keyrings_dir }}/docker.asc] {{ docker_apt_uri }} {{ ansible_distribution_release }} stable


### PR DESCRIPTION
Allows the user to override the apt server to pull from, for example
when using an apt proxy.  Previous value is new default, so playbooks
not using this won't see any change.

Notes:
    v2:
    - reword commit message
