### PR TITLE
feat: add docker images prune cron job to docker_setup role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@
 docker_apt_key_url: "https://download.docker.com/linux/debian/gpg"
 docker_apt_keyrings_dir: "/etc/apt/keyrings"
 docker_apt_uri: "https://download.docker.com/linux/debian"
+docker_cron_image_prune: false  # enable/disable cronjob for regular automatic image cleanup
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,3 +110,10 @@
     append: yes
   when: (item.docker is defined) and item.docker
   with_items: "{{ users }}"
+
+- name: Ensure that docker image prune cron job is present.
+  ansible.builtin.cron:
+    name: docker image prune
+    special_time: weekly
+    user: root
+    job: "docker image prune --all --force"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,3 +117,4 @@
     special_time: weekly
     user: root
     job: "docker image prune --all --force"
+    disabled: "{{ not docker_cron_image_prune }}"


### PR DESCRIPTION
With 863e244f01cbdf47f4c19ba19f14ea8006b7a0be we copied the local role from the Netz39 playbooks.  The plan was to migrate to this external role here, but that PR is still not merged as of today.  Meanwhile more changes emerged however, this PR is porting those over.  Intentionally not linking the private repo here where this comes from.  @24367dfa acknowledged this port in private conversation.