### PR TITLE
Add GitHub workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          # Check out the complete branch history
+          fetch-depth: 0
+
+      - name: "Generate release changelog"
+        id: generate-release-changelog
+        # Version 2.4 is available, but creates scrambled output
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)
+          stripHeaders: "true"
+          stripGeneratorNotice: "true"
+
+      - name: Extract the VERSION name
+        id: get-version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: "Create GitHub release"
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: "${{ steps.get-version.outputs.VERSION }}"
+          body: "${{ steps.generate-release-changelog.outputs.changelog }}"
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for creating releases. The workflow is triggered by pushing tags that follow the version pattern `v*.*.*`. It includes several steps to check out the code, generate a release changelog, extract the version name, and create a GitHub release as a draft.

Key changes:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R43): Added a new workflow named "Create Release" that triggers on tag pushes, checks out the code, generates a changelog, extracts the version, and creates a draft release.