### PR TITLE
:arrow_up: workflow: Update changelog generator action to use janhein…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Generate release changelog"
         id: generate-release-changelog
         # Version 2.4 is available, but creates scrambled output
-        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        uses: janheinrichmerker/action-github-changelog-generator@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)


### PR DESCRIPTION
…richmerker version

Link to repo: https://github.com/janheinrichmerker/action-github-changelog-generator

This seems to be the current home of the same action as before. The Social media contacts suggest this is the same person :)