### PR TITLE
:page_facing_up: Add license for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Netz39 Administrators <admin@netz39.de>
+# SPDX-License-Identifier: MIT
+---
 name: Create Release
 
 on:


### PR DESCRIPTION
Fixes the following reuse run output for commit
bb10cb2b5c7e8b3ff70f839fdb31f806113d268f:

    # MISSING COPYRIGHT AND LICENSING INFORMATION

    The following files have no copyright and licensing information:
    * .github/workflows/release.yml

    # SUMMARY

    * Bad licenses: 0
    * Deprecated licenses: 0
    * Licenses without file extension: 0
    * Missing licenses: 0
    * Unused licenses: 0
    * Used licenses: MIT, CC-BY-4.0, CC0-1.0
    * Read errors: 0
    * Files with copyright information: 9 / 10
    * Files with license information: 9 / 10

    Unfortunately, your project is not compliant with version 3.2 of the REUSE Specification :-(

    # RECOMMENDATIONS

    * Fix missing copyright/licensing information: For one or more files, the tool cannot find copyright and/or licensing information. You typically do this by adding 'SPDX-FileCopyrightText' and 'SPDX-License-Identifier' tags to each file. The tutorial explains additional ways to do this: <https://reuse.software/tutorial/>

Link: https://api.reuse.software/info/github.com/netz39/ansible-role-host-docker