### PR TITLE
Specify max line length for Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = true
+max_line_length = 72


### PR DESCRIPTION
This pull request includes a small change to the `.editorconfig` file. The change introduces new settings for Markdown files to trim trailing whitespace and set a maximum line length of 72 characters.

According to https://github.com/editorconfig/specification/issues/25 this is not part of the core specification, but editors understand it nonetheless.