### PR TITLE
:sparkles: Remove not used anonymous volumes too

### DIFF
--- a/files/docker-image-prune.service
+++ b/files/docker-image-prune.service
@@ -8,4 +8,4 @@ After=docker.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker image prune --all --force
+ExecStart=/usr/bin/docker image prune --all --volumes --force


### PR DESCRIPTION
## change

Some containers (e.g. mariadb in default configuration) make use of volumes managed by Docker (see `docker volume` command).  Old volumes not used by containers might pile up and eat storage.  Remove those, too.

Compare output of `docker system prune` when called with or without `--volumes` option:

```
% docker system prune --all
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container 
  - all images without at least one container associated to them 
  - all build cache
```

Notice the additional line when calling with the option:

```
% docker system prune --all --volumes
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container 
  - all anonymous volumes not used by at least one container 
  - all images without at least one container associated to them 
  - all build cache
```

## discussion

Not sure if this should be squashed into the existing command which is controlled with `docker_image_prune` or if we should introduce a separate variable for pruning volumes only?  Opinions?

