### PR TITLE
Add configuration for the log size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ You can go with just the defaults.
     * Default: *empty*
     * Description: Enable IPv6 for the docker default network and set
       the given CIDR.
+* `docker_log_max_size`:
+    * Default: *100m*
+    * Description: Set the maximum size of a single log file.
+      See [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/)
+      in docker documentation for details.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ docker_image_prune: false  # enable/disable cronjob for regular automatic image 
 docker_data_root: "/var/lib/docker"
 docker_storage_driver: "overlay2"
 docker_v6_cidr: ""
+docker_log_max_size: "100m"

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -8,7 +8,7 @@
     "exec-opts": ["native.cgroupdriver=systemd"],
     "log-driver": "json-file",
         "log-opts": {
-            "max-size": "100m"
+            "max-size": "{{ docker_log_max_size }}",
         },
     "data-root": "{{ docker_data_root }}",
     "storage-driver": "{{ docker_storage_driver }}"


### PR DESCRIPTION
This pull request introduces a new configuration option, `docker_log_max_size`, to allow users to customize the maximum size of Docker log files. The changes include updates to documentation, default settings, and the Docker daemon configuration template.

### New Feature: Configurable Log File Size

* **Documentation Update**: Added details about the new `docker_log_max_size` option in the `README.md`, including its default value (`100m`) and a link to Docker's documentation for further details.
* **Default Configuration**: Introduced `docker_log_max_size` with a default value of `"100m"` in `defaults/main.yml`.
* **Template Update**: Updated the `templates/daemon.json.j2` file to use the `docker_log_max_size` variable instead of the hardcoded value `"100m"`. This makes the log size configurable.