### PR TITLE
:bug: templates: daemon.json: Remove trailing comma

### DIFF
--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -8,7 +8,7 @@
     "exec-opts": ["native.cgroupdriver=systemd"],
     "log-driver": "json-file",
         "log-opts": {
-            "max-size": "{{ docker_log_max_size }}",
+            "max-size": "{{ docker_log_max_size }}"
         },
     "data-root": "{{ docker_data_root }}",
     "storage-driver": "{{ docker_storage_driver }}"


### PR DESCRIPTION
The last element in a list must not have a comma, otherwise it is invalid json.

Fixes: 9290c819e457 ("Allow to configure the max size of log files in daemon configuration")