### PR TITLE
Always install the prune service, but limit timer activation

### DIFF
--- a/tasks/docker_image_prune.yml
+++ b/tasks/docker_image_prune.yml
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: Install Docker image-prune systemd unit, if enabled
+- name: Copy docker-image-prune.service file
+  ansible.builtin.copy:
+    src: files/docker-image-prune.service
+    dest: /etc/systemd/system/docker-image-prune.service
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Install Docker image-prune timer unit, if enabled
   when: docker_image_prune
   block:
-    - name: Copy docker-image-prune.service file
-      ansible.builtin.copy:
-        src: files/docker-image-prune.service
-        dest: /etc/systemd/system/docker-image-prune.service
-        mode: "0644"
-      notify: Reload systemd
-
     - name: Copy docker-image-prune.timer file
       ansible.builtin.copy:
         src: files/docker-image-prune.timer


### PR DESCRIPTION
Change the prune service installationso that the systemd service unit is always available, but timer activation depends on the configuration.

This allows to trigger image pruning from sources other than the timer, even if the timer is not used.

Behavior of the installation does not change, other than availability of the prune systemd unit.