### PR TITLE
Add python3-standard-pipes to Debian 13 installation

### DIFF
--- a/tasks/apt_source_setup_trixie.yml
+++ b/tasks/apt_source_setup_trixie.yml
@@ -11,6 +11,7 @@
       - apt-transport-https
       - ca-certificates
       - gnupg2
+      - python3-standard-pipes
 
 # Link: https://docs.docker.com/engine/install/debian/#install-using-the-repository
 - name: Prepare apt with key and sources entry


### PR DESCRIPTION
The [standard-pipes](https://pypi.org/project/standard-pipes/) library has been removed from the Python standard libraries in [PEP 594](https://peps.python.org/pep-0594/), but is needed by the docker tasks.

Add the Debian package in Debian 13 installations to satisfy the dependency.

The library is not needed to install Docker, but will be missing when subsequent tasks try to interact with Docker.

This fixes #39 