### PR TITLE
Add python3-setuptools to Trixie-based installations

### DIFF
--- a/tasks/apt_source_setup_trixie.yml
+++ b/tasks/apt_source_setup_trixie.yml
@@ -12,6 +12,7 @@
       - ca-certificates
       - gnupg2
       - python3-standard-pipes
+      - python3-setuptools
 
 # Link: https://docs.docker.com/engine/install/debian/#install-using-the-repository
 - name: Prepare apt with key and sources entry


### PR DESCRIPTION
The Debian Trixie cloud image is missing python setuptools, because they are no longer packaged with Python 3.13.

While the role can be executed and successfully installs Docker, subsequent Ansible tasks to install a Docker container will fail due to this missing dependency.

Tested on a fresh Debian 13 cloud image.