### PR TITLE
feat: Let dockerd validate its configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,7 @@
     src: templates/daemon.json.j2
     dest: /etc/docker/daemon.json
     mode: "0644"
+    validate: "dockerd --validate --config-file='%s'"
   notify: Restart docker
 
 - name: Place admin users in docker group


### PR DESCRIPTION
The docker daemon allows to validate a configuration file without starting the daemon itself.  This integrates nicely with the validate parameter of the ansible template module.

Link: https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file
Link: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html#parameter-validate