### PR TITLE
Remove check and warning about old CRON setup

### DIFF
--- a/tasks/docker_image_prune.yml
+++ b/tasks/docker_image_prune.yml
@@ -24,19 +24,3 @@
         name: docker-image-prune.timer
         enabled: yes
         state: started
-
-
-
-# Note: This check can go away in a few releases
-
-- name: Check for old docker image prune cron job
-  ansible.builtin.shell: "crontab -l | grep 'docker image prune --all --force'"
-  register: cron_check
-  ignore_errors: true
-  failed_when: false
-  changed_when: false
-
-- name: Print warning about old cron job
-  ansible.builtin.debug:
-    msg: "Warning: Old docker image prune cron job found. Please remove it manually using 'sudo crontab -e' and delete the line containing 'docker image prune --all --force'."
-  when: cron_check.rc == 0


### PR DESCRIPTION
This setup has been introduced in release [0.5.0](https://github.com/netz39/ansible-role-host-docker/releases/tag/v0.5.0) to support required manual intervention during the upgrade process.

This transition should be concluded by now in any active installation and the message can be removed to save time on execution and help the restructuring efforts in #35.